### PR TITLE
Shagun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .ipynb_checkpoints
 # covasim_testbed.ipynb
+__pycache__/helper_stats.cpython-36.pyc
+app.code-workspace
+covidestim_estimates.csv
+nst-est2019-01.csv
+covasim_testbed_shagun.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 # covasim_testbed.ipynb
 __pycache__/helper_stats.cpython-36.pyc
 app.code-workspace
-covidestim_estimates.csv
 nst-est2019-01.csv
 covasim_testbed_shagun.ipynb


### PR DESCRIPTION
- Changed min event size # of people to 10
- Using covidestim infection data at the state-level instead of applying the CDC under reporting factor 
- Removed under_rep_factor from num_preinfections calculation in the test_intervention function as under reporting is taken into account in the incidence_avg for both state and national numbers. 