### PR TITLE
remove under rep factor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ app.code-workspace
 nst-est2019-01.csv
 covasim_testbed_shagun.ipynb
 covidactnow_api.txt
+covasim_testbed_shagun.ipynb
+testing_under_rep_factor.ipynb


### PR DESCRIPTION
Closing issue #126 

No longer using under reporting factor for calculating infections at the national level. 
Instead using covidestim state level data to calculate national level total infections, last 10 days infections and incidence average. 

Also fixed the incidence average calculation at the state level to use infections from last 7 days (instead of last 10 days).